### PR TITLE
align the text

### DIFF
--- a/07 - SportsStore/SportsStore/src/app/store/store.component.html
+++ b/07 - SportsStore/SportsStore/src/app/store/store.component.html
@@ -6,7 +6,7 @@
     </div>
     <div class="row">
   
-      <div class="col-3 p-2">
+      <div class="col-3 py-2">
         <button class="btn btn-block btn-outline-primary" (click)="changeCategory()">
           Home
         </button>
@@ -17,7 +17,7 @@
         </button>
       </div>
   
-      <div class="col-9 p-2">
+      <div class="col-9 py-2">
         <div *ngFor="let product of products" class="card m-1 p-1 bg-light">
           <h4>
             {{product.name}}


### PR DESCRIPTION
`p-2` can add left padding of the `col-3` and `col-9`, it will lead to the top words(SPORTS STORE ) are not aligned. So, it's better to using `py-2` and just add y axios padding.

![screen shot 2018-10-15 at 4 31 20 pm](https://user-images.githubusercontent.com/6081537/46939112-0a3a4f00-d098-11e8-9cfa-0c06d31fc058.png)
