### PR TITLE
Fixed verify token

### DIFF
--- a/09 - SportsStore - Admin/SportsStore/authMiddleware.js
+++ b/09 - SportsStore - Admin/SportsStore/authMiddleware.js
@@ -25,7 +25,7 @@ module.exports = function (req, res, next) {
             || req.url.startsWith("/orders")) && req.method != "POST")) {
         let token = req.headers["authorization"];
         if (token != null && token.startsWith("Bearer<")) {
-            token = token.substring(7, token.length - 1);
+            token = token.substring(7);
             try {
                 jwt.verify(token, APP_SECRET);
                 next();


### PR DESCRIPTION
The `token` get an error value. `jwt.verify(token, APP_SECRET);` will always throw an error. 

![screen shot 2018-10-17 at 2 55 47 pm](https://user-images.githubusercontent.com/6081537/47067871-42b76580-d21d-11e8-8c67-ec952e665627.png)
